### PR TITLE
Add timeout arg to the CLI. Closes #35.

### DIFF
--- a/tricount_extractor/client/client.py
+++ b/tricount_extractor/client/client.py
@@ -10,6 +10,7 @@ ACCESS_TOKEN_URL = f"{BASE_URL}/v1/session-registry-installation"
 USER_URL = f"{BASE_URL}/v1/user"
 USER_AGENT = "com.bunq.tricount.android:RELEASE:7.0.7:3174:ANDROID:13:C"
 MAX_RETRY = 3
+DEFAULT_TIMEOUT = 5
 
 
 class TricountClient:
@@ -18,9 +19,11 @@ class TricountClient:
         *,
         transport: httpx.BaseTransport | None = None,
         max_retry: int = MAX_RETRY,
+        timeout: float | None = DEFAULT_TIMEOUT,
     ):
         self._transport = transport
         self._max_retry = max_retry
+        self._timeout = timeout
 
         self._application_id = self._generate_application_id()
 
@@ -48,7 +51,7 @@ class TricountClient:
             return self._retry_get_registry(registry_id, retry=retry)
 
     def _get_registry(self, registry_id: str) -> httpx.Response:
-        with httpx.Client(transport=self._transport) as client:
+        with httpx.Client(transport=self._transport, timeout=self._timeout) as client:
             response = client.get(
                 self._registry_url,
                 params=self._registry_params(registry_id),
@@ -79,7 +82,7 @@ class TricountClient:
             self._retry_authenticate(retry=retry)
 
     def _authenticate(self) -> None:
-        with httpx.Client(transport=self._transport) as client:
+        with httpx.Client(transport=self._transport, timeout=self._timeout) as client:
             response = client.post(
                 ACCESS_TOKEN_URL,
                 json=self._generate_access_token_payload(),

--- a/tricount_extractor/main.py
+++ b/tricount_extractor/main.py
@@ -1,8 +1,8 @@
 import httpx
 
-from tricount_extractor.parse_args import parse_args
-from tricount_extractor.client.client import TricountClient
+from tricount_extractor.client.client import DEFAULT_TIMEOUT, TricountClient
 from tricount_extractor.models.registry import Registry
+from tricount_extractor.parse_args import parse_args
 from tricount_extractor.saver import RegistrySaver
 
 
@@ -13,8 +13,11 @@ class Processor:
         folder: str,
         *,
         transport: httpx.BaseTransport | None = None,
+        timeout: float | None = DEFAULT_TIMEOUT,
     ) -> None:
-        errors = self._process(registry_ids, folder, transport=transport)
+        errors = self._process(
+            registry_ids, folder, transport=transport, timeout=timeout
+        )
         if len(errors) == 0:
             return
         raise ExceptionGroup("failed to process some tricounts", errors)
@@ -25,9 +28,10 @@ class Processor:
         folder: str,
         *,
         transport: httpx.BaseTransport | None = None,
+        timeout: float | None,
     ) -> list[Exception]:
         errors = []
-        with TricountClient(transport=transport) as client:
+        with TricountClient(transport=transport, timeout=timeout) as client:
             for registry_id in registry_ids:
                 error = self._process_registry_id(client, registry_id, folder)
                 if error is None:
@@ -56,7 +60,7 @@ def main() -> None:
     args = parse_args()
 
     try:
-        Processor().process(args.registry_id, args.folder)
+        Processor().process(args.registry_id, args.folder, timeout=args.timeout)
     except ExceptionGroup as exc:
         print(f"error occured while processing registries: {exc.exceptions}")
         return 1

--- a/tricount_extractor/parse_args.py
+++ b/tricount_extractor/parse_args.py
@@ -1,5 +1,7 @@
 import argparse
 
+from tricount_extractor.client.client import DEFAULT_TIMEOUT
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -20,4 +22,24 @@ def parse_args() -> argparse.Namespace:
         required=True,
         help="Output folder path where registry Excel files will be saved",
     )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        action="store",
+        type=float_or_none,
+        default=DEFAULT_TIMEOUT,
+        help=(
+            f"HTTP request timeout in seconds (default: {DEFAULT_TIMEOUT}). "
+            "Use None for no timeout."
+        ),
+    )
     return parser.parse_args()
+
+
+def float_or_none(value):
+    if value is None or value.lower() == "none":
+        return None
+    try:
+        return float(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"'{value}' is not a valid float or 'None'")


### PR DESCRIPTION
Exposes the `HTTPX.Timeout` option to the CLI.

`uv run --all-groups pytest` ran without any issue.

