### PR TITLE
Feature/fix network issues

### DIFF
--- a/tricount_extractor/client/client.py
+++ b/tricount_extractor/client/client.py
@@ -13,7 +13,7 @@ BASE_URL = "https://api.tricount.bunq.com"
 ACCESS_TOKEN_URL = f"{BASE_URL}/v1/session-registry-installation"
 USER_URL = f"{BASE_URL}/v1/user"
 USER_AGENT = "com.bunq.tricount.android:RELEASE:7.0.7:3174:ANDROID:13:C"
-MAX_RETRY = 3
+MAX_RETRY = 10
 BACKOFF_BASE_SECONDS = 1.0
 DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
 RETRYABLE_EXCEPTIONS = (httpx.TimeoutException, httpx.TransportError)

--- a/tricount_extractor/client/client.py
+++ b/tricount_extractor/client/client.py
@@ -1,5 +1,9 @@
+import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
+from functools import wraps
+from typing import ParamSpec, TypeVar
 
 import httpx
 
@@ -10,6 +14,28 @@ ACCESS_TOKEN_URL = f"{BASE_URL}/v1/session-registry-installation"
 USER_URL = f"{BASE_URL}/v1/user"
 USER_AGENT = "com.bunq.tricount.android:RELEASE:7.0.7:3174:ANDROID:13:C"
 MAX_RETRY = 3
+BACKOFF_BASE_SECONDS = 1.0
+DEFAULT_TIMEOUT = httpx.Timeout(connect=5.0, read=30.0, write=10.0, pool=5.0)
+RETRYABLE_EXCEPTIONS = (httpx.TimeoutException, httpx.TransportError)
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def retry_on_network_error(method: Callable[P, R]) -> Callable[P, R]:
+    @wraps(method)
+    def wrapper(self, *args: P.args, **kwargs: P.kwargs) -> R:
+        for attempt in range(self._max_retry):
+            try:
+                return method(self, *args, **kwargs)
+            except RETRYABLE_EXCEPTIONS as exc:
+                if attempt + 1 >= self._max_retry:
+                    msg = f"max retry {self._max_retry} reached: {exc!r}"
+                    raise ConnectionError(msg) from exc
+                time.sleep(BACKOFF_BASE_SECONDS * 2**attempt)
+        raise AssertionError("unreachable")
+
+    return wrapper
 
 
 class TricountClient:
@@ -27,28 +53,16 @@ class TricountClient:
         self._access_token: AccessToken | None = None
 
     def __enter__(self):
-        self._retry_authenticate()
+        self._authenticate()
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self._access_token = None
         return None
 
+    @retry_on_network_error
     def get_registry(self, registry_id: str) -> httpx.Response:
-        return self._retry_get_registry(registry_id)
-
-    def _retry_get_registry(self, registry_id: str, retry: int = 0) -> httpx.Response:
-        if retry >= self._max_retry:
-            msg = f"max retry {self._max_retry} reached"
-            raise ConnectionError(msg)
-        try:
-            return self._get_registry(registry_id)
-        except httpx.TimeoutException:
-            retry += 1
-            return self._retry_get_registry(registry_id, retry=retry)
-
-    def _get_registry(self, registry_id: str) -> httpx.Response:
-        with httpx.Client(transport=self._transport) as client:
+        with httpx.Client(transport=self._transport, timeout=DEFAULT_TIMEOUT) as client:
             response = client.get(
                 self._registry_url,
                 params=self._registry_params(registry_id),
@@ -68,18 +82,9 @@ class TricountClient:
     def _registry_params(registry_id: str) -> dict[str, str]:
         return {"public_identifier_token": registry_id}
 
-    def _retry_authenticate(self, retry: int = 0) -> None:
-        if retry >= self._max_retry:
-            msg = f"max retry {self._max_retry} reached"
-            raise ConnectionError(msg)
-        try:
-            self._authenticate()
-        except httpx.TimeoutException:
-            retry += 1
-            self._retry_authenticate(retry=retry)
-
+    @retry_on_network_error
     def _authenticate(self) -> None:
-        with httpx.Client(transport=self._transport) as client:
+        with httpx.Client(transport=self._transport, timeout=DEFAULT_TIMEOUT) as client:
             response = client.post(
                 ACCESS_TOKEN_URL,
                 json=self._generate_access_token_payload(),

--- a/tricount_extractor/tests/test_client.py
+++ b/tricount_extractor/tests/test_client.py
@@ -1,0 +1,124 @@
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from tricount_extractor.client.client import BACKOFF_BASE_SECONDS, TricountClient
+
+
+AUTH_RESPONSE = httpx.Response(
+    200,
+    json={
+        "Response": [
+            {"Token": {"token": "tok"}},
+            {"UserPerson": {"id": "uid"}},
+        ]
+    },
+)
+REGISTRY_RESPONSE = httpx.Response(200, json={"Response": []})
+
+
+def _auth_only_handler(request):
+    return AUTH_RESPONSE
+
+
+def test_authenticate_recovers_after_transient_failures():
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise httpx.ReadTimeout("boom")
+        return AUTH_RESPONSE
+
+    with patch("tricount_extractor.client.client.time.sleep") as sleep:
+        with TricountClient(transport=httpx.MockTransport(handler)) as client:
+            assert client._access_token.access_token == "tok"
+
+    assert calls["n"] == 3
+    assert [c.args[0] for c in sleep.call_args_list] == [
+        BACKOFF_BASE_SECONDS,
+        BACKOFF_BASE_SECONDS * 2,
+    ]
+
+
+def test_authenticate_raises_connection_error_after_max_retry():
+    original = httpx.ConnectError("nope")
+    calls = {"n": 0}
+
+    def handler(request):
+        calls["n"] += 1
+        raise original
+
+    max_retry = 3
+    with patch("tricount_extractor.client.client.time.sleep") as sleep:
+        with pytest.raises(ConnectionError) as exc_info:
+            with TricountClient(
+                transport=httpx.MockTransport(handler), max_retry=max_retry
+            ):
+                pass
+
+    assert calls["n"] == max_retry
+    assert sleep.call_count == max_retry - 1
+    assert exc_info.value.__cause__ is original
+
+
+def test_get_registry_recovers_after_transient_failures():
+    registry_calls = {"n": 0}
+
+    def handler(request):
+        if "session-registry-installation" in str(request.url):
+            return AUTH_RESPONSE
+        registry_calls["n"] += 1
+        if registry_calls["n"] < 2:
+            raise httpx.ReadTimeout("boom")
+        return REGISTRY_RESPONSE
+
+    with patch("tricount_extractor.client.client.time.sleep") as sleep:
+        with TricountClient(transport=httpx.MockTransport(handler)) as client:
+            response = client.get_registry("reg-001")
+
+    assert response.status_code == 200
+    assert registry_calls["n"] == 2
+    sleep.assert_called_once_with(BACKOFF_BASE_SECONDS)
+
+
+def test_get_registry_raises_connection_error_after_max_retry():
+    original = httpx.ReadTimeout("nope")
+    registry_calls = {"n": 0}
+
+    def handler(request):
+        if "session-registry-installation" in str(request.url):
+            return AUTH_RESPONSE
+        registry_calls["n"] += 1
+        raise original
+
+    max_retry = 3
+    with patch("tricount_extractor.client.client.time.sleep") as sleep:
+        with TricountClient(
+            transport=httpx.MockTransport(handler), max_retry=max_retry
+        ) as client:
+            with pytest.raises(ConnectionError) as exc_info:
+                client.get_registry("reg-001")
+
+    assert registry_calls["n"] == max_retry
+    assert sleep.call_count == max_retry - 1
+    assert exc_info.value.__cause__ is original
+
+
+def test_get_registry_does_not_retry_on_http_error():
+    calls = {"n": 0}
+
+    def handler(request):
+        if "session-registry-installation" in str(request.url):
+            return AUTH_RESPONSE
+        calls["n"] += 1
+        return httpx.Response(404, json={"error": "not found"})
+
+    with patch("tricount_extractor.client.client.time.sleep") as sleep:
+        with TricountClient(transport=httpx.MockTransport(handler)) as client:
+            with pytest.raises(httpx.HTTPStatusError):
+                client.get_registry("reg-001")
+
+    assert calls["n"] == 1
+    sleep.assert_not_called()


### PR DESCRIPTION
Fixes #35 without adding a `--timeout` CLI flag (alternative to #36).
The root cause of "max retry 3 reached" on large registries wasn't a missing knob — it was two bad defaults compounding:
- `httpx.Client()` was constructed with no explicit timeout, so it inherited httpx's 5 second read timeout. That's too short for large registry downloads.
- The retry loop retried instantly on `TimeoutException`, so three back-to-back 5 second timeouts failed within ~15 seconds with an opaque error message.