### PR TITLE
  Add split_view sheet with per-member transaction breakdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,5 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+.idea/

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ uv run tricount-extractor -id abc123 xyz789 -f ./output
 
 ## Output Format
 
-Each registry is saved as an Excel file with 5 sheets:
+Each registry is saved as an Excel file with 6 sheets:
 
 ### 1. members
 Registry participants with their details.
@@ -87,6 +87,19 @@ Final balance for each member (who owes/is owed).
 |--------|-------------|
 | member | Member name |
 | balance | Net balance (positive = owed, negative = owes) |
+
+### 6. split_view
+Detailed view of each transaction showing each member's net position per entry.
+
+| Column | Description |
+|--------|-------------|
+| Date | Entry date |
+| Description | Expense description |
+| Category | Expense category |
+| Type | Transaction type label |
+| Cost | Total cost (0 for reimbursements) |
+| Currency | Currency code |
+| [Member names] | Each member has a column showing their net balance for this entry (amount owed minus amount paid) |
 
 ## Development
 

--- a/tricount_extractor/models/entry.py
+++ b/tricount_extractor/models/entry.py
@@ -61,6 +61,19 @@ class Entry:
     def is_reimbursement(self) -> bool:
         return self.type_transaction is EntryTypeTransaction.BALANCE
 
+    @property
+    def is_income(self) -> bool:
+        return self.type_transaction is EntryTypeTransaction.INCOME
+
+    @property
+    def transaction_type_label(self) -> str:
+        if self.is_reimbursement:
+            return "Transfer"
+        elif self.is_income:
+            return "Income"
+        else:
+            return "Expense"
+
     def to_dict(self) -> dict:
         return {
             "entry_id": self.id,
@@ -72,6 +85,7 @@ class Entry:
             "original_currency": self.amount_local.currency,
             "payer": self.payer_name,
             "is_reimbursement": self.is_reimbursement,
+            "is_income": self.is_income,
             "category": self.category,
         }
 
@@ -85,6 +99,7 @@ class Entry:
             "description": self.description,
             "payer": self.payer_name,
             "is_reimbursement": self.is_reimbursement,
+            "is_income": self.is_income,
         }
         return [{**base, **a.to_dict()} for a in self.allocations]
 

--- a/tricount_extractor/models/registry.py
+++ b/tricount_extractor/models/registry.py
@@ -48,6 +48,7 @@ class Registry:
             "allocations": self._to_allocations_dataframe(),
             "attachments": self._to_attachments_dataframe(),
             "balances": self._to_balance_dataframe(),
+            "split_view": self._to_split_view_dataframe(),
         }
 
     def _to_entries_dataframe(self) -> pd.DataFrame:
@@ -61,9 +62,9 @@ class Registry:
     def _to_balance_dataframe(self) -> pd.DataFrame:
         balances = {m.display_name: 0.0 for m in self.members}
         for e in self.entries:
-            balances[e.payer_name] += abs(e.amount.value)
+            balances[e.payer_name] += e.amount.value
             for a in e.allocations:
-                balances[a.member_name] -= abs(a.amount.value)
+                balances[a.member_name] -= a.amount.value
         rows = [{"member": k, "balance": round(v, 2)} for k, v in balances.items()]
         return (
             pd.DataFrame(rows)
@@ -79,3 +80,31 @@ class Registry:
         if not rows:
             return pd.DataFrame(columns=["entry_id", "url"])
         return pd.DataFrame(rows)
+
+    def _to_split_view_dataframe(self) -> pd.DataFrame:
+        member_names = sorted([m.display_name for m in self.members])
+        rows = []
+
+        for e in self.entries:
+            row = {
+                "Date": e.date.strftime("%Y-%m-%d"),
+                "Description": e.description,
+                "Category": e.category,
+                "Type": e.transaction_type_label,
+                "Cost": e.amount.value if not e.is_reimbursement else 0.0,
+                "Currency": e.amount.currency,
+            }
+
+            allocation_map = {a.member_name: a.amount.value for a in e.allocations}
+            for member_name in member_names:
+                amount_owed = allocation_map.get(member_name, 0.0)
+                amount_paid = e.amount.value if member_name == e.payer_name else 0.0
+                row[member_name] = amount_owed - amount_paid
+
+            rows.append(row)
+
+        if not rows:
+            columns = ["Date", "Description", "Category", "Type", "Cost", "Currency"] + member_names
+            return pd.DataFrame(columns=columns)
+
+        return pd.DataFrame(rows).sort_values("Date").reset_index(drop=True)


### PR DESCRIPTION
  Fix Balance calculation.

  - Add split_view sheet to Excel output showing net position for each member per transaction
  - Add transaction_type_label and is_income properties to Entry model
  - Include is_income field in entry and allocation dictionaries
  - Remove abs() calls in balance calculations to preserve signed values
  - Update README to document the new split_view sheet format
  - Add .idea/ to .gitignore

  The split_view sheet provides a detailed view where each member has a column showing their net balance (amount owed minus amount paid) for every entry.

  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>